### PR TITLE
Fix: Correct parameter order in router function signatures

### DIFF
--- a/routers/auth.py
+++ b/routers/auth.py
@@ -47,8 +47,8 @@ async def create_profile_image(user: models.User, db: Session, openai_api_client
 @router.post("/register", response_model=schemas.User)
 async def register_user(
     user_in: schemas.UserCreate,
+    request: Request, 
     bg: BackgroundTasks,
-    request: Request, # Added request
     db: Session = Depends(database.get_db),
 ):
     """
@@ -85,8 +85,8 @@ async def register_user(
 
 @router.post("/login", response_model=schemas.Token)
 async def login_for_access_token(
+    request: Request, 
     form_data: OAuth2PasswordRequestForm = Depends(), 
-    request: Request, # Added request
     db: Session = Depends(database.get_db)
 ):
     """


### PR DESCRIPTION
Resolves a SyntaxError ("non-default argument follows default argument") that occurred after introducing the `request: Request` parameter to several router functions.

The following functions in `routers/auth.py` had their parameters reordered to ensure all non-default arguments precede default arguments:
- `register_user`
- `login_for_access_token`

The signature of `update_users_me` in `routers/users.py` was verified to be already correct.