### PR TITLE
Refactor: Modify GPT-4V inputs for safer DALL-E prompts

### DIFF
--- a/services/profile_image.py
+++ b/services/profile_image.py
@@ -190,9 +190,9 @@ async def _generate_styled_dalle_prompt_with_gpt4v(
 
     gender_specific_details = ""
     if user_gender == "女性":
-        gender_specific_details = "女性的な顔つき、細い体、長いまつげ、魅力的なポーズをしています。"
+        gender_specific_details = "全体的に柔らかな印象で、やや女性的なニュアンスのスタイル。"
     elif user_gender == "男性":
-        gender_specific_details = "男性的な顔つき、太い体、短い太いまゆげ、力強いポーズをしています。"
+        gender_specific_details = "全体的にシャープな印象で、やや男性的なニュアンスのスタイル。"
     else:
         gender_specific_details = "指定なし。中性的な特徴で。"
 


### PR DESCRIPTION
This commit refactors the input provided to GPT-4V for generating DALL-E 3 prompts, specifically for the gender-specific details. The aim is to create more neutral and less physically descriptive prompts to avoid triggering OpenAI's content policies, which previously resulted in 400 errors with 'image_generation_user_error'.

Changes in `services/profile_image.py`:
- Modified the `_generate_styled_dalle_prompt_with_gpt4v` function.
- Replaced detailed Japanese phrases for 'feminine' and 'masculine' gender characteristics with more general descriptions focusing on "impression" and "nuance" rather than specific physical attributes like "slender body" or "strong pose".

This change is intended to increase the success rate of profile image generation by DALL·E 3.