### PR TITLE
feat: Add global variable for image selection (frontend)

### DIFF
--- a/static/collaboration_ai_ui.html
+++ b/static/collaboration_ai_ui.html
@@ -1063,6 +1063,7 @@
     let talkModeConfirmed = false;
     let mediaRecorder = null;
     let recordedChunks = [];
+    let selectedImageForGeneration = null;
 
     // --- トークン管理 ---
     function saveToken(token) { localStorage.setItem('paleio_token', token); }


### PR DESCRIPTION
This commit adds a global JavaScript variable `selectedImageForGeneration` to `static/collaboration_ai_ui.html`. I intended this variable to store the file you select via the new image upload button for the image generation modes.

However, my subsequent attempts to add the necessary event listener to populate this variable, and to add the event listener for the main image generation execution button, continued to fail due to persistent issues with applying the code changes.

Frontend JavaScript implementation for image generation interactivity (file selection handling, execution logic, dynamic dropdowns, result display) remains blocked by these limitations.

The backend API and logic for all four new image generation modes are complete as per the previous commit and are ready for testing via API tools.