### PR TITLE
fix: Correct final SyntaxError in video.py

### DIFF
--- a/routers/video.py
+++ b/routers/video.py
@@ -1793,5 +1793,3 @@ else:
     logger.info(f"Static files URL prefix for generated content: /static/{STATIC_VIDEO_DIR_BASE.name}")
     
     uvicorn.run(app, host="0.0.0.0", port=8001)
-
-```


### PR DESCRIPTION
Removes a remaining markdown code block delimiter (```) from near the end of the routers/video.py file.

This error also prevented the Uvicorn server from starting up. This commit should finally resolve the syntax errors in this file, allowing the server to load the video router correctly. This is my third attempt to fix such errors introduced during file modifications.