### PR TITLE
Fix syntax error in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-
 import os
 from dotenv import load_dotenv
 
@@ -44,4 +43,3 @@ DEEPL_LANG_MAP = {
     "zh": "ZH",
     # Add more as needed
 }
-```


### PR DESCRIPTION
## Summary
- remove stray triple backtick from `config.py` to restore valid python

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683a81cb9890832787ece1bfdae8e8bb