### PR TITLE
Fix auth dependency import for video router

### DIFF
--- a/routers/video.py
+++ b/routers/video.py
@@ -23,6 +23,8 @@ from moviepy.editor import (
 from moviepy.video.fx.all import resize as moviepy_resize 
 from moviepy.config import change_settings
 from PIL import Image 
+from models import User
+from dependencies import get_current_active_user
 
 # Import config variables from config.py
 try:


### PR DESCRIPTION
## Summary
- import User and get_current_active_user before defining video endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683a8594893083279b6859503c294a43