### PR TITLE
fix: Specify bcrypt as extra for passlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,7 @@ elevenlabs
 assemblyai
 deepl
 stability-sdk
-passlib
-bcrypt
+passlib[bcrypt]
 
 # Media Processing
 moviepy


### PR DESCRIPTION
I updated requirements.txt to change 'passlib' to 'passlib[bcrypt]' and removed the separate 'bcrypt' entry. This aims to ensure bcrypt is correctly installed as a dependency of passlib, addressing potential ModuleNotFoundError for passlib.